### PR TITLE
Redditから投稿タイトルを取得する

### DIFF
--- a/formatter.php
+++ b/formatter.php
@@ -1,70 +1,50 @@
 <?php
 require __DIR__ . '/vendor/autoload.php';
-require __DIR__ . '/mastodon/getActions/GetGlobalTimelineApi.php';
 require __DIR__ . '/mastodon/postActions/PostTootApi.php';
 require 'convertEntity.php';
 require 'originalList.php';
+require __DIR__ . '/lib/RedditPostFetcher.php';
+require __DIR__ . '/lib/Translator.php';
 use YuzuruS\Mecab\Markovchain;
 
 $formatter = new formatter();
 $formatter->execToot();
 class formatter {
     function execToot(){
-        // マルコフ連鎖の元となるテキストを生成する
-        $rawText = $this->generateText();
-        //print_r($rawText, false);
-        $convertedText = $this->convertToAko($rawText);
-        //print_r($convertedText, false);
-        $markovText = $this->convertToMarkov($convertedText);
-        //print_r($markovText, false);
-        if(isset($markovText)) {
-            $this->toot($markovText);
-            return;
-        } else {
+        try {
+            // マルコフ連鎖の元となるテキストを生成する
+            $rawText = $this->generateText();
+            //print_r($rawText, false);
+            $convertedText = $this->convertToAko($rawText);
+            //print_r($convertedText, false);
+            $markovText = $this->convertToMarkov($convertedText);
+            //print_r($markovText, false);
+            if(isset($markovText)) {
+                $this->toot($markovText);
+                return;
+            } else {
+                return;
+            }
+        } catch (\RuntimeException $e) {
+            // データ取得や翻訳でエラーが発生した場合は、ログ出力して何もせずに終了する
+            error_log($e->getMessage());
             return;
         }
     }
     
-    // 連合TLからトゥートを取得し整形する
-    function generateText(){
+    // Redditの投稿本文を翻訳してマルコフ連鎖の元テキストを生成する
+    function generateText(): string
+    {
+        $redditFetcher = new RedditPostFetcher();
+        $translator = new Translator();
 
-        // 連合TL取得APIを叩きトゥートを取得
-        $getGlobaltimeLineApi = new getActions\GetGlobalTimelineApi();
-        $ary = $getGlobaltimeLineApi->getGlobalTimeline();
+        // Redditから連結された投稿タイトルを取得
+        $postText = $redditFetcher->fetchSubredditTitles(150);
 
-        $ol = new originalList();
-        $string = "";
-        $i = 0; // ループ用
-        foreach($ary as $skey => $sValue) {
-            // 先頭40トゥートを抽出対象とする
-            if($i == 40) {
-                break;
-            }
-            
-            // 取得したJSONをパースしhtmlタグを削除したトゥートだけを抽出する
-            $rawValue = strip_tags($sValue['content']);
-            
-            // 英字・記号が含まれていたらスキップ
-            if(preg_match('/[a-zA-Z0-9!-\/:-@¥\[-`{-~\]]/', $rawValue)) {
-                continue;
-            }
-            
-            // 末尾が句読点や感嘆符じゃなかったら文節判定用に「。」を付ける
-            if(substr($rawValue,-1) != "。" 
-                && substr($rawValue,-1) != "、" 
-                && substr($rawValue,-1) != "！" 
-                && substr($rawValue,-1) != "？")
-            {
-                $rawValue .= "。";
-            }
-            
-            // 文章を連結する
-            $string .= $rawValue;
-            $i++;
-        }
-        //$rawText = $string . $ol->implodeSentences(); // この行を有効化するとオリジナルテキストも参照する
-        
-        return $string;
+        // 取得した本文を翻訳
+        $translatedText = $translator->translate($postText);
+
+        return $translatedText;
     }
     // 変換リストに沿った文章の加工を行う
     function convertToAko($rawText) {

--- a/lib/RedditPostFetcher.php
+++ b/lib/RedditPostFetcher.php
@@ -1,0 +1,56 @@
+<?php
+
+class RedditPostFetcher
+{
+    /**
+     * r/visualnovelsサブレディットから複数の投稿タイトルを取得し、指定文字数まで連結して返します。
+     *
+     * @param int $maxLength 連結後の最大文字数
+     * @return string 連結された投稿タイトル
+     * @throws \RuntimeException 投稿が見つからなかった場合やAPIエラーの場合
+     */
+    public function fetchSubredditTitles(int $maxLength = 150): string
+    {
+        $url = 'https://www.reddit.com/r/visualnovels/.json';
+
+        // User-Agentを設定
+        $options = [
+            'http' => [
+                'header' => "User-Agent: php:markov_akane_bot:0.1\r\n"
+            ]
+        ];
+        $context = stream_context_create($options);
+
+        $json = @file_get_contents($url, false, $context);
+        if ($json === false) {
+            throw new \RuntimeException('Failed to fetch data from Reddit API.');
+        }
+
+        $data = json_decode($json, true);
+
+        if (!isset($data['data']['children'])) {
+            throw new \RuntimeException('Invalid JSON structure from Reddit API.');
+        }
+
+        $concatenatedTitles = '';
+        foreach ($data['data']['children'] as $post) {
+            if (isset($post['data']['title']) && !empty(trim($post['data']['title']))) {
+                $title = trim($post['data']['title']);
+                $titleWithPeriod = $title . '.'; // 各タイトルの終わりに句点を追加
+
+                if (mb_strlen($concatenatedTitles) + mb_strlen($titleWithPeriod) <= $maxLength) {
+                    $concatenatedTitles .= $titleWithPeriod;
+                } else {
+                    // 文字数制限に達したらループを抜ける
+                    break;
+                }
+            }
+        }
+
+        if (empty($concatenatedTitles)) {
+            throw new \RuntimeException('No titles found in r/visualnovels subreddit.');
+        }
+
+        return $concatenatedTitles;
+    }
+}

--- a/lib/Translator.php
+++ b/lib/Translator.php
@@ -1,0 +1,55 @@
+<?php
+
+class Translator
+{
+    private const SOURCE_LANG = 'en';
+    private const TARGET_LANG = 'ja';
+
+    /**
+     * 英語のテキストを日本語に翻訳します。
+     *
+     * @param string $text 翻訳するテキスト
+     * @return string 翻訳されたテキスト
+     * @throws \RuntimeException 翻訳に失敗した場合
+     */
+    public function translate(string $text): string
+    {
+        // 注意: この実装はAPIキー不要の簡易的なサービスを利用しています。
+        // 本番環境で利用する場合、より安定した翻訳API（DeepL, Google Translate等）の
+        // 契約と、SDKまたはライブラリの利用を強く推奨します。
+
+        $url = sprintf(
+            'https://api.mymemory.translated.net/get?q=%s&langpair=%s|%s',
+            urlencode($text),
+            self::SOURCE_LANG,
+            self::TARGET_LANG
+        );
+
+        // User-Agentを設定
+        $options = [
+            'http' => [
+                'header' => "User-Agent: php:markov_akane_bot:0.1\r\n"
+            ]
+        ];
+        $context = stream_context_create($options);
+
+        $response = @file_get_contents($url, false, $context);
+        if ($response === false) {
+            throw new \RuntimeException('Failed to fetch data from translation API.');
+        }
+
+        $data = json_decode($response, true);
+
+        // レスポンスコードが200以外はエラー
+        if (!isset($data['responseStatus']) || $data['responseStatus'] !== 200) {
+            throw new \RuntimeException('Translation API returned an error. Response: ' . $response);
+        }
+
+        if (isset($data['responseData']['translatedText']) && !empty($data['responseData']['translatedText'])) {
+            return $data['responseData']['translatedText'];
+        }
+
+        // その他の理由で翻訳に失敗した場合
+        throw new \RuntimeException('Failed to translate text. Response: ' . $response);
+    }
+}

--- a/test_reddit_fetcher.php
+++ b/test_reddit_fetcher.php
@@ -1,0 +1,22 @@
+<?php
+
+require_once __DIR__ . '/lib/RedditPostFetcher.php';
+
+echo "RedditPostFetcher のテストを開始します。\n\n";
+
+$fetcher = new RedditPostFetcher();
+
+try {
+    // 150文字制限でタイトルを取得
+    $text = $fetcher->fetchSubredditTitles(150);
+
+    echo "テスト成功！\n";
+    echo "取得したテキスト（" . mb_strlen($text) . "文字）:\n";
+    echo "----------------------------------------\n";
+    echo $text;
+    echo "\n----------------------------------------\n";
+
+} catch (RuntimeException $e) {
+    echo "テスト中にエラーが発生しました。\n";
+    echo "エラーメッセージ: " . $e->getMessage() . "\n";
+}


### PR DESCRIPTION
## 今回の作業内容メモ

このメモは、Gemini CLIエージェントとの共同作業で実施された変更点をまとめたものです。

### 1. Redditからのデータ取得機能の追加と変更

-   **`lib/RedditPostFetcher.php` の新規作成と修正**
    -   Redditの `r/visualnovels` サブレディットから投稿タイトルを取得する機能を追加しました。
    -   複数の投稿タイトルを連結し、各タイトルの終わりにピリオド「.」を付与するようにしました。
    -   指定された最大文字数（デフォルト150文字）を超えないように連結します。
    -   APIアクセス失敗時やタイトルが見つからない場合に `RuntimeException` をスローするようになりました。

### 2. 翻訳機能の追加

-   **`lib/Translator.php` の新規作成**
    -   英語のテキストを日本語に翻訳するクラスを実装しました（MyMemory Translated APIを使用）。
    -   翻訳元言語は常に英語、翻訳先言語は常に日本語となるよう定数で定義しました。
    -   翻訳に失敗した場合に `RuntimeException` をスローするようになりました。

### 3. メイン処理 (`formatter.php`) の変更

-   **マルコフ連鎖の元データソースの変更**
    -   従来のMastodon連合タイムラインからのテキスト取得を廃止し、上記で作成した `RedditPostFetcher` と `Translator` を利用して、Redditの投稿タイトル（翻訳済み）をマルコフ連鎖の元データとして使用するように変更しました。
    -   データ取得や翻訳の過程で発生した `RuntimeException` を捕捉し、エラーログを出力して安全に処理を終了するよう、`execToot` メソッドにエラーハンドリングを追加しました。

### 4. 開発環境の整備

-   ローカル環境にPHPがインストールされていなかったため、Homebrewを使用してPHPをインストールしました。

### 5. テストとデバッグ

-   各機能（`RedditPostFetcher`, `Translator`）の単体テストを作成し、動作確認を行いました。
-   `r/Moe` サブレディットの特性（本文投稿が少ない）により `RedditPostFetcher` のエラーが発生したため、`r/visualnovels` からタイトルを取得するよう変更し、問題を解決しました。
-   正規表現のデリミタの問題や、メソッドシグネチャの不一致など、いくつかのデバッグと修正を行いました。

### 6. Gitコミット

-   上記の一連の変更は、`feat: Integrate Reddit titles for Markov chain generation` というコミットメッセージでGitリポジトリにコミット済みです。

---